### PR TITLE
Convert registry to VC Extension Registry.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,11 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a 
+# they will be requested for review when someone opens a
 # pull request.
 *       @msporny
+*       @burnburn
+*       @ChristopherA
+*       @kimdhamilton
+*       @jandrieu
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Credential Status Method Registry</title>
+    <title>Verifiable Credentials Extension Registry</title>
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
     <!--
       === NOTA BENE ===
@@ -16,10 +16,10 @@
         specStatus: "CG-DRAFT",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
-        shortName: "vc-status-registry",
+        shortName: "vc-extension-registry",
 
         // subtitle
-        subtitle: "Known mechanisms for expressing the current status of credentials",
+        subtitle: "Known extensions for use in Verifiable Credentials",
 
         // if you wish the publication date to be other than today, set this
         // publishDate:  "2009-08-06",
@@ -30,13 +30,24 @@
         // previousMaturity:  "WD",
 
         // extend the bibliography entries
-        //localBiblio: ccg.localBiblio,
+        localBiblio: {
+          "VC-DATA-MODEL": {
+            title: "Verifiable Credentials Data Model 1.0",
+            href: "https://www.w3.org/TR/vc-data-model/",
+            authors: [
+              "Manu Sporny", "Dave Longley", "Grant Noble",
+              "Daniel C. Burnett", "David Chadwick"
+            ],
+            status: "NOTE",
+            publisher: "Verifiable Claims Working Group"
+          }
+        },
 
         github: "https://github.com/w3c-ccg/vc-status-registry",
         includePermalinks: false,
 
         // if there a publicly available Editor's Draft, this is the link
-        edDraftURI: "https://w3c-ccg.github.io/vc-status-registry/",
+        edDraftURI: "https://w3c-ccg.github.io/vc-extension-registry/",
 
         // if this is a LCWD, uncomment and set the end of its review period
         // lcEnd: "2009-08-05",
@@ -80,7 +91,7 @@
     <section id='abstract'>
       <p>
 This document serves as an informative registry for all known
-Credential Status Methods and their associated specifications.
+Verifiable Credentials extensions and their associated specifications.
       </p>
     </section>
 
@@ -100,16 +111,146 @@ or send them to
 <section>
 <h1>Introduction</h1>
 <p>
-This document contains a list of all known Credential Status
-Methods and their associated specifications.
+This document contains a list of all known Verifiable Credential extensions
+and their associated specifications.
 </p>
 </section>
 
-<section>
-<h1>The Registry</h1>
+<section class="normative">
+<h1>The Registration Process</h1>
+<p>
+Software implementers may find that the existing Verifiable Credentials
+extensions listed in this repository are not suitable for their
+use case and may need to add a new method to this registry.
+Adding a Verifiable Credentials extension to this registry is designed to be a
+lightweight, community-driven process. In order to add a new method to this
+registry, an implementer MUST:
+</p>
+
+<ol>
+  <li>
+Implement at least an experimental version of the Verifiable Credentials
+extension.
+  </li>
+  <li>
+Create a specification describing the new Verifiable Credential extension that
+is publicly available and intended to be conformant with the Verifiable
+Credentials specification [[!VC-DATA-MODEL]].
+  </li>
+  <li>
+Request that the specification be added to this registry by submitting a
+Github Pull Request that adds the new method to the list of existing
+extensions.
+  </li>
+</ol>
 
 <p>
-This table summarizes the Credential Status Method specifications currently
+Specifications that do not meet these criteria will not be accepted.
+Old listings which are clearly not being developed, or which fall out of
+conformance may be removed.
+</p>
+
+<p>
+Implementers that would like help or guidance during this process are urged
+to join the
+<a href="https://github.com/w3c-ccg/w3c-ccg.github.io/blob/master/joining.md">
+W3C Credentials Community Group</a> and request assistance via the
+<a href="https://lists.w3.org/Archives/Public/public-credentials/">mailing list</a>.
+</p>
+</section>
+
+<section class="normative">
+  <h1>The Registry</h1>
+
+<section class="normative">
+<h1>Proof Methods</h1>
+
+<p>
+This table summarizes the Proof Method specifications currently
+in development. The table lists the method name, associated specification,
+authors, stability of the specification, and conformance test suite
+(if applicable).
+</p>
+
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Method Name</th>
+      <th>Specification</th>
+      <th>Authors</th>
+      <th>Stability</th>
+      <th>Test Suite</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+          Ed25519Signature2018
+      </td>
+      <td>
+          <a href="https://w3c-dvcg.github.io/lds-ed25519-2018/">
+            Ed25519 Signature 2018</a>
+      </td>
+      <td>
+          Manu Sporny, Dave Longley
+      </td>
+      <td>
+        Experimental
+      </td>
+      <td>
+        None
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+          KoblitzSignature2016
+      </td>
+      <td>
+          <a href="https://w3c-dvcg.github.io/lds-koblitz2016/">
+            Ed25519 Signature 2018</a>
+      </td>
+      <td>
+          Manu Sporny, Dave Longley
+      </td>
+      <td>
+        Experimental
+      </td>
+      <td>
+        None
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+          RsaSignature2018
+      </td>
+      <td>
+          <a href="https://w3c-dvcg.github.io/lds-rsa2018/">
+            RSA Signature 2018</a>
+      </td>
+      <td>
+          Manu Sporny, Dave Longley
+      </td>
+      <td>
+        Experimental
+      </td>
+      <td>
+        None
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+</section>
+
+<section class="normative">
+<h1>Status Methods</h1>
+
+<p>
+This table summarizes the Status Method specifications currently
 in development. The table lists the method name, associated specification,
 authors, stability of the specification, and conformance test suite
 (if applicable).
@@ -146,21 +287,81 @@ authors, stability of the specification, and conformance test suite
       </td>
     </tr>
 
+  </tbody>
+</table>
+</section>
+
+<section class="normative">
+<h1>Data Schema Validation Methods</h1>
+
+<p>
+This table summarizes the Data Schema Validation Method specifications currently
+in development. The table lists the method name, associated specification,
+authors, stability of the specification, and conformance test suite
+(if applicable).
+</p>
+
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Method Name</th>
+      <th>Specification</th>
+      <th>Authors</th>
+      <th>Stability</th>
+      <th>Test Suite</th>
+    </tr>
+  </thead>
+
+  <tbody>
     <tr>
       <td>
-          CredentialStatusBlockchain2017
       </td>
       <td>
-          In Process
       </td>
       <td>
-          Manu Sporny, Dave Longley
       </td>
       <td>
-        Experimental
       </td>
       <td>
-        None
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+</section>
+
+<section class="normative">
+<h1>Refresh Methods</h1>
+
+<p>
+This table summarizes the Credential Status Method specifications currently
+in development. The table lists the method name, associated specification,
+authors, stability of the specification, and conformance test suite
+(if applicable).
+</p>
+
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Method Name</th>
+      <th>Specification</th>
+      <th>Authors</th>
+      <th>Stability</th>
+      <th>Test Suite</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
       </td>
     </tr>
 
@@ -169,6 +370,85 @@ authors, stability of the specification, and conformance test suite
 
 </section>
 
+<section class="normative">
+<h1>Terms of Use Methods</h1>
+
+<p>
+This table summarizes the Terms of Use specifications currently
+in development. The table lists the method name, associated specification,
+authors, stability of the specification, and conformance test suite
+(if applicable).
+</p>
+
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Method Name</th>
+      <th>Specification</th>
+      <th>Authors</th>
+      <th>Stability</th>
+      <th>Test Suite</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+</section>
+
+<section class="normative">
+<h1>Evidence Methods</h1>
+
+<p>
+This table summarizes the Evidence Method specifications currently
+in development. The table lists the method name, associated specification,
+authors, stability of the specification, and conformance test suite
+(if applicable).
+</p>
+
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Method Name</th>
+      <th>Specification</th>
+      <th>Authors</th>
+      <th>Stability</th>
+      <th>Test Suite</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+</section>
 </section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,9 @@
         // only "name" is required
         editors: [
           { name: "Manu Sporny", url: "http://manu.sporny.org/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" }
+            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" },
+          { name: "Daniel C. Burnett", url: "https://www.linkedin.com/in/daburnett/",
+            company: "ConsenSys", companyURL: "https://consensys.net/"}
         ],
 
         // authors, add as many as you like.

--- a/index.html
+++ b/index.html
@@ -36,9 +36,9 @@
             href: "https://www.w3.org/TR/vc-data-model/",
             authors: [
               "Manu Sporny", "Dave Longley", "Grant Noble",
-              "Daniel C. Burnett", "David Chadwick"
+              "Daniel C. Burnett", "David Chadwick", "Brent Zundel"
             ],
-            status: "NOTE",
+            status: "CR",
             publisher: "Verifiable Claims Working Group"
           }
         },


### PR DESCRIPTION
This expands the vc-status-registry to the vc-extension-registry per the VCWG issue https://github.com/w3c/vc-data-model/issues/530 . 

This would require the adoption of a new Work Item for the CCG, to maintain the VC Extension Registry, which has been approved by the VCWG here: https://www.w3.org/2019/04/30-vcwg-minutes.html#resolution07

I'll submit the Work Item request to the CCG shortly.