### PR TITLE
Add reserved proof suites from VCWG JSON-LD Context.

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,44 @@ authors, stability of the specification, and conformance test suite
 
     <tr>
       <td>
+          EcdsaSecp256k1Signature2019
+      </td>
+      <td>
+          <a href="https://w3c-dvcg.github.io/lds-ecdsa-secp256k1-2019/">
+            EcdsaSecp256k1Signature2019</a>
+      </td>
+      <td>
+        None
+      </td>
+      <td>
+        Reserved in https://www.w3.org/2018/credentials/v1
+      </td>
+      <td>
+        None
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+          EcdsaSecp256r1Signature2019
+      </td>
+      <td>
+          <a href="https://w3c-dvcg.github.io/lds-ecdsa-secp256r1-2019/">
+            EcdsaSecp256r1Signature2019</a>
+      </td>
+      <td>
+        None
+      </td>
+      <td>
+        Reserved in https://www.w3.org/2018/credentials/v1
+      </td>
+      <td>
+        None
+      </td>
+    </tr>
+
+    <tr>
+      <td>
           RsaSignature2018
       </td>
       <td>


### PR DESCRIPTION
We need to add the reserved curves from the VCWG JSON-LD Context for secp256k1 (Bitcoin and Ethereum) and secp256r1 (NIST/FIDO/U2F devices).