### PR TITLE
Fix broken links in Section 3.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@ authors, stability of the specification, and conformance test suite
           Ed25519Signature2018
       </td>
       <td>
-          <a href="https://w3c-dvcg.github.io/lds-ed25519-2018/">
+          <a href="https://w3c-ccg.github.io/lds-ed25519-2018/">
             Ed25519 Signature 2018</a>
       </td>
       <td>
@@ -210,7 +210,7 @@ authors, stability of the specification, and conformance test suite
           RsaSignature2018
       </td>
       <td>
-          <a href="https://w3c-dvcg.github.io/lds-rsa2018/">
+          <a href="https://w3c-ccg.github.io/lds-rsa2018/">
             RSA Signature 2018</a>
       </td>
       <td>

--- a/index.html
+++ b/index.html
@@ -195,26 +195,7 @@ authors, stability of the specification, and conformance test suite
             Ed25519 Signature 2018</a>
       </td>
       <td>
-          Manu Sporny, Dave Longley
-      </td>
-      <td>
-        Experimental
-      </td>
-      <td>
-        None
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-          KoblitzSignature2016
-      </td>
-      <td>
-          <a href="https://w3c-dvcg.github.io/lds-koblitz2016/">
-            Ed25519 Signature 2018</a>
-      </td>
-      <td>
-          Manu Sporny, Dave Longley
+          Markus Sabadello
       </td>
       <td>
         Experimental


### PR DESCRIPTION
The links in Section 3.1 in https://w3c-ccg.github.io/vc-extension-registry/ are broken. This pull request fixes them. 