### PR TITLE
Deprecate RsaSignature2018

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@ authors, stability of the specification, and conformance test suite
           Manu Sporny, Dave Longley
       </td>
       <td>
-        Experimental
+        Deprecated
       </td>
       <td>
         None


### PR DESCRIPTION
Change stability status of proof method RsaSignature2018 from Experimental to Deprecated.

Address #5